### PR TITLE
Update meshtastic2hass.py

### DIFF
--- a/src/meshtastic2hass/meshtastic2hass.py
+++ b/src/meshtastic2hass/meshtastic2hass.py
@@ -431,7 +431,7 @@ def initMQTT():
     mqtt = _globals.getMQTT()
     client_id = f'meshtastic2hass-{random.randint(0, 100)}'
     try:
-        mqtt = mqttClient.Client(client_id, True)
+        mqtt = mqttClient.Client(mqttClient.CallbackAPIVersion.VERSION1, client_id, True)
         _globals.setMQTT(mqtt)
         _globals.setTopicPrefix(args.mqtt_topic_prefix)
         mqtt.on_message = onMQTTMessage


### PR DESCRIPTION
Fix "unsupported callback API version error" for paho-MQTT 2.x version request to set API version.